### PR TITLE
composer.json https fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://packagist.drupal-composer.org/"
+            "url": "https://packagist.drupal-composer.org/"
         },
 
         {


### PR DESCRIPTION
[Composer\Downloader\TransportException]  
  Your configuration does not allow connections to http://packagist.drupal-composer.org/packages.json. See https://getcomposer.org/doc/06-config.md#secure-http for  
  details.
